### PR TITLE
Use role dependencies instead of explicit `include_role`s

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -39,3 +39,10 @@ galaxy_info:
 dependencies:
   - role: ccdc.package_manager_configuration
   - role: geerlingguy.mac.homebrew
+    vars:
+      # This is overwritten by our group_vars (cpp.build-machines)
+      homebrew_taps:
+        - name: xfreebird/utils
+      homebrew_installed_packages:
+        - xfreebird/utils/kcpassword
+

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -38,11 +38,3 @@ galaxy_info:
 
 dependencies:
   - role: ccdc.package_manager_configuration
-  - role: geerlingguy.mac.homebrew
-    vars:
-      # This is overwritten by our group_vars (cpp.build-machines)
-      homebrew_taps:
-        - name: xfreebird/utils
-      homebrew_installed_packages:
-        - xfreebird/utils/kcpassword
-

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -36,4 +36,6 @@ galaxy_info:
     - desktop
     - integrationtesting
 
-dependencies: []
+dependencies:
+  - role: ccdc.package_manager_configuration
+  - role: geerlingguy.mac.homebrew

--- a/tasks/AlmaLinux.yml
+++ b/tasks/AlmaLinux.yml
@@ -1,8 +1,4 @@
 ---
-- name: Set up package managers for required tools
-  ansible.builtin.include_role:
-    name: ccdc.package_manager_configuration
-
 - name: Install desktop environment
   ansible.builtin.package:
     name: "{{ package }}"

--- a/tasks/Darwin.yml
+++ b/tasks/Darwin.yml
@@ -16,6 +16,16 @@
   changed_when: false
   become: true
 
+- name: Install Homebrew + kcpassword
+  ansible.builtin.include_role:
+    name: geerlingguy.mac.homebrew
+  vars:
+    # This is overwritten by our group_vars (cpp.build-machines)
+    homebrew_taps:
+      - name: xfreebird/utils
+    homebrew_installed_packages:
+      - xfreebird/utils/kcpassword
+
 - name: Set autoLoginUser for current user
   community.general.osx_defaults:
     domain: /Library/Preferences/com.apple.loginwindow

--- a/tasks/Darwin.yml
+++ b/tasks/Darwin.yml
@@ -16,22 +16,6 @@
   changed_when: false
   become: true
 
-- name: Install Homebrew + kcpassword
-  ansible.builtin.include_role:
-    name: geerlingguy.mac.homebrew
-  vars:
-    # This is overwritten by our group_vars (cpp.build-machines)
-    homebrew_taps:
-      - name: xfreebird/utils
-    homebrew_installed_packages:
-      - xfreebird/utils/kcpassword
-
-# - name: Add kcpassword utility for autologin
-#   community.general.homebrew:
-#     name: kcpassword
-#     state: present
-#   become: true
-
 - name: Set autoLoginUser for current user
   community.general.osx_defaults:
     domain: /Library/Preferences/com.apple.loginwindow

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -1,8 +1,4 @@
 ---
-- name: Set up package managers for required tools
-  ansible.builtin.include_role:
-    name: ccdc.package_manager_configuration
-
 - name: Install desktop environment
   ansible.builtin.package:
     name: "{{ package }}"

--- a/tasks/Windows.yml
+++ b/tasks/Windows.yml
@@ -6,10 +6,18 @@
   become: true
 
 - name: Enable autologon for vagrant
-  ansible.windows.win_command: powershell.exe Start-Process -FilePath "C:\\ProgramData\\chocolatey\\bin\\Autologon.exe" -ArgumentList '"/accepteula" vagrant . {{ windows_autologon_password }}'
+  ansible.windows.win_command: >
+    powershell.exe Start-Process
+      -FilePath "C:\\ProgramData\\chocolatey\\bin\\Autologon.exe"
+      -ArgumentList '"/accepteula" vagrant . {{ windows_autologon_password }}'
 
 - name: Disable screen saver
-  ansible.windows.win_shell: Set-ItemProperty "HKCU:\Control Panel\Desktop" -Name ScreenSaveActive -Value 0 -Type DWord
+  ansible.windows.win_shell: >
+    Set-ItemProperty
+      "HKCU:\Control Panel\Desktop"
+      -Name ScreenSaveActive
+      -Value 0
+      -Type DWord
 
 - name: Disable monitor and standby idle timeout
   ansible.windows.win_command: powercfg -x -{{ timeout }} 0

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: Set OS-specific variables for {{ ansible_os_family }}-{{ ansible_distribution }}-{{ ansible_distribution_major_version }}
+- name: Set OS-specific variables for {{ ansible_os_family }}-{{ ansible_distribution }}-{{ ansible_distribution_major_version }}  # noqa: name[template]
   ansible.builtin.include_vars: "{{ item }}"
   with_first_found:
     - files:
@@ -11,7 +11,7 @@
       skip: true
   tags: vars
 
-- name: Set up desktop environment on {{ ansible_os_family }}-{{ ansible_distribution }}-{{ ansible_distribution_major_version }}
+- name: Set up desktop environment on {{ ansible_os_family }}-{{ ansible_distribution }}-{{ ansible_distribution_major_version }}  # noqa: name[template]
   ansible.builtin.include_tasks: "{{ item }}"
   with_first_found:
     - files:

--- a/vars/macos.yml
+++ b/vars/macos.yml
@@ -6,7 +6,7 @@ homebrew_user: "{{ ansible_user }}"
 homebrew_taps:
   - name: xfreebird/utils
   - name: xcodesorg/made
-current_user: "{{ lookup('env','USER') }}"
+current_user: "{{ lookup('env', 'USER') }}"
 
 homebrew_installed_packages:
   - kcpassword


### PR DESCRIPTION
This will cause Ansible to de-duplicate rule inclusion, speeding up provisioning time and reducing the amount of interference through repeat provisioning.